### PR TITLE
added new Request REQ_DISABLE_PID_FILTER

### DIFF
--- a/dvbservice/src/main/java/info/martinmarinov/dvbservice/Request.java
+++ b/dvbservice/src/main/java/info/martinmarinov/dvbservice/Request.java
@@ -138,6 +138,13 @@ enum Request {
                     (long) dvbDevice.getDeviceFilter().getProductId() // parameter 6
             );
         }
+    }),
+    REQ_DISABLE_PID_FILTER(new Executor() {
+        @Override
+        public Response execute(DvbDevice dvbDevice, long... payload) throws DvbException {
+            dvbDevice.disablePidFilter();
+            return Response.SUCCESS;
+        }
     });
 
     private final static String TAG = Request.class.getSimpleName();

--- a/dvbservice/src/test/java/info/martinmarinov/dvbservice/RequestTest.java
+++ b/dvbservice/src/test/java/info/martinmarinov/dvbservice/RequestTest.java
@@ -145,6 +145,17 @@ public class RequestTest {
         assertThat(response[6], is(0x2838L)); // USB product id
     }
 
+    @Test
+    public void testDisablePidFilter() throws Exception {
+        long[] response = getRawResponse(6);
+
+        assertThat(response.length, is(1));
+        assertThat(response[0], is(1L)); // success
+
+        // verify hardware was called
+        verify(dvbDevice).disablePidFilter();
+    }
+
     /** Helper to do serialization/deserialization to bytes */
     private long[] getRawResponse(int requestOrdinal, long ... reqArgs) {
         try {


### PR DESCRIPTION
Current workflow is:
- Connect to control and transfer sockets
- REQ_TUNE (req=2)
- REQ_GET_STATUS (req=3) polling, till Lock is confirmed
- REQ_SET_PIDS (req=4) with all PIDs (must be known beforehand from somewhere..) to be able to parse PMT
- REQ_SET_PIDS (req=4) use obtained PMT data to move from _some sort of_ MPTS to _some sort of_ SPTS
- read the modified stream from transfer socket

issue: this only works if the PIDs are known. To parse PMT data we need `passFullTsStream` to be trueotherwise `reset()` in DvbDemux would always filter to PID 0. Setting passFullTsStream was not exposed as a Request, only active in debug view of the project.

I have added a new Request named REQ_DISABLE_PID_FILTER at the end of the enum to keep the existing Ordinal numbering stable.

Now we can use this workflow:
- Connect to control and transfer sockets
- REQ_DISABLE_PID_FILTER (req=6) to allow full MPTS
- REQ_TUNE (req=2)
- REQ_GET_STATUS (req=3) polling, till Lock is confirmed
- parse PMT data from the MPTS stream
- REQ_SET_PIDS (req=4) use obtained PMT data to move from real MPTS to _some sort of_ SPTS
- read the modified stream from transfer socket