### PR TITLE
TUNE Request can optionally set DVB-C symbolrate

### DIFF
--- a/drivers/src/main/java/info/martinmarinov/drivers/DvbDevice.java
+++ b/drivers/src/main/java/info/martinmarinov/drivers/DvbDevice.java
@@ -57,11 +57,15 @@ public abstract class DvbDevice implements Closeable {
     // Debug string to identify device for debugging purposes
     public abstract String getDebugString();
 
-    protected abstract void tuneTo(long freqHz, long bandwidthHz, @NonNull DeliverySystem deliverySystem) throws DvbException;
+    protected abstract void tuneTo(long freqHz, long bandwidthHz, @NonNull DeliverySystem deliverySystem, long dvbcSymbolRate) throws DvbException;
+
+    public final void tune(long freqHz, long bandwidthHz, @NonNull DeliverySystem deliverySystem, long dvbcSymbolRate) throws DvbException {
+        tuneTo(freqHz, bandwidthHz, deliverySystem, dvbcSymbolRate);
+        if (dvbDemux != null) dvbDemux.reset();
+    }
 
     public final void tune(long freqHz, long bandwidthHz, @NonNull DeliverySystem deliverySystem) throws DvbException {
-        tuneTo(freqHz, bandwidthHz, deliverySystem);
-        if (dvbDemux != null) dvbDemux.reset();
+        tune(freqHz, bandwidthHz, deliverySystem, 0L);
     }
 
     public int readDroppedUsbFps() throws DvbException {

--- a/drivers/src/main/java/info/martinmarinov/drivers/file/DvbFileDevice.java
+++ b/drivers/src/main/java/info/martinmarinov/drivers/file/DvbFileDevice.java
@@ -74,7 +74,7 @@ public class DvbFileDevice extends DvbDevice {
     }
 
     @Override
-    protected void tuneTo(long freqHz, long bandwidthHz, @NonNull DeliverySystem deliverySystem) throws DvbException {
+    protected void tuneTo(long freqHz, long bandwidthHz, @NonNull DeliverySystem deliverySystem, long dvbcSymbolRate) throws DvbException {
         this.isTuned = freqHz == this.freq && bandwidthHz == this.bandwidth;
     }
 

--- a/drivers/src/main/java/info/martinmarinov/drivers/usb/DvbFrontend.java
+++ b/drivers/src/main/java/info/martinmarinov/drivers/usb/DvbFrontend.java
@@ -46,4 +46,7 @@ public interface DvbFrontend {
     Set<DvbStatus> getStatus() throws DvbException;
     void setPids(int ... pids) throws DvbException;
     void disablePidFilter() throws DvbException;
+
+    // Optional: called before setParams() to set DVB-C symbol rate (default no-op)
+    default void setDvbcSymbolRate(long symbolRate) {}
 }

--- a/drivers/src/main/java/info/martinmarinov/drivers/usb/DvbUsbDevice.java
+++ b/drivers/src/main/java/info/martinmarinov/drivers/usb/DvbUsbDevice.java
@@ -177,8 +177,11 @@ public abstract class DvbUsbDevice extends DvbDevice {
     }
 
     @Override
-    protected void tuneTo(final long freqHz, final long bandwidthHz, @NonNull final DeliverySystem deliverySystem) throws DvbException {
+    protected void tuneTo(final long freqHz, final long bandwidthHz, @NonNull final DeliverySystem deliverySystem, final long dvbcSymbolRate) throws DvbException {
         Check.notNull(frontend, "Frontend not initialized");
+        if (dvbcSymbolRate > 0) {
+            frontend.setDvbcSymbolRate(dvbcSymbolRate);
+        }
         retry(RETRIES, new ThrowingRunnable<DvbException>() {
             @Override
             public void run() throws DvbException {

--- a/drivers/src/main/java/info/martinmarinov/drivers/usb/silabs/Si2168.java
+++ b/drivers/src/main/java/info/martinmarinov/drivers/usb/silabs/Si2168.java
@@ -63,7 +63,7 @@ public class Si2168 implements DvbFrontend {
     private final static int TIMEOUT_MS = 70;
     private final static int NO_STREAM_ID_FILTER = 0xFFFFFFFF;
     private final static int DVBT2_STREAM_ID = 0;
-    private final static int DVBC_SYMBOL_RATE = 0;
+    private final static long DEFAULT_DVBC_SYMBOL_RATE = 6_900_000L;
 
     private final Resources resources;
     private final I2cAdapter i2c;
@@ -81,6 +81,7 @@ public class Si2168 implements DvbFrontend {
     private Si2168Data.Si2168Chip chip;
     private DvbTuner tuner;
     private DeliverySystem deliverySystem;
+    private long dvbcSymbolRate = DEFAULT_DVBC_SYMBOL_RATE;
 
     private boolean hasLockStatus = false;
 
@@ -353,7 +354,7 @@ public class Si2168 implements DvbFrontend {
         if (deliverySystem == DeliverySystem.DVBC) {
             //noinspection PointlessBitwiseExpression
             si2168_cmd_execute(new byte[] {
-                    (byte) 0x14, (byte) 0x00, (byte) 0x02 , (byte) 0x11, (byte) (((DVBC_SYMBOL_RATE / 1000) >> 0) & 0xff), (byte) ( ((DVBC_SYMBOL_RATE / 1000) >> 8) & 0xff)
+                    (byte) 0x14, (byte) 0x00, (byte) 0x02 , (byte) 0x11, (byte) (((dvbcSymbolRate / 1000) >> 0) & 0xff), (byte) ( ((dvbcSymbolRate / 1000) >> 8) & 0xff)
             }, 6, 4);
         }
 
@@ -463,6 +464,10 @@ public class Si2168 implements DvbFrontend {
 
     public I2cAdapter.I2GateControl gateControl() {
         return gateControl;
+    }
+
+    public void setDvbcSymbolRate(long symbolRate) {
+        this.dvbcSymbolRate = (symbolRate > 0) ? symbolRate : DEFAULT_DVBC_SYMBOL_RATE;
     }
 
     private final I2cAdapter.I2GateControl gateControl = new I2cAdapter.I2GateControl() {

--- a/dvbservice/src/main/java/info/martinmarinov/dvbservice/Request.java
+++ b/dvbservice/src/main/java/info/martinmarinov/dvbservice/Request.java
@@ -76,9 +76,11 @@ enum Request {
             // Typical value for DVB-T is 8_000_000
             DeliverySystem deliverySystem = DeliverySystem.values()[(int) payload[2]];
             // Check enum for actual values
+	    long dvbcSymbolRate = (payload.length > 3) ? payload[3] : 0L;
+            // DVB-C symbol rate in symbols/sec (e.g. 6_900_000); 0 = use device default
 
             Log.d(TAG, "Client requested tune to " + frequency + " Hz with bandwidth " + bandwidth + " Hz with delivery system " + deliverySystem);
-            dvbDevice.tune(frequency, bandwidth, deliverySystem);
+            dvbDevice.tune(frequency, bandwidth, deliverySystem, dvbcSymbolRate);
             return Response.SUCCESS;
         }
     }),


### PR DESCRIPTION
With the Mygica PT-362 I was able to test DVB-C successfully. So Si2168 seems to work fine with it.
Setting the DVB-C symbolrate is mandatory though. Previously "0" was hardcoded. Setting it to a reasonable default value such as 6900 kSym/s, which is the Standard in Europe worked. 

I have expanded the TUNE request to allow dynamically setting the symbolrate if needed. It is all optioanal and also an additional parameter. Therefore it should not break any older apps that access the driver.

Closes #56 
Closes #31